### PR TITLE
Fix pyshut shutdown call and validate CLI

### DIFF
--- a/pyshut.py
+++ b/pyshut.py
@@ -5,24 +5,29 @@ import time
 import sys
 
 def temporizar(tiempo):
-	t = 0 
-	while (t < tiempo):
-		print "Minuto {}".format(t)
-		time.sleep(60)
-		t = t + 1
+        t = 0
+        while t < tiempo:
+                print("Minuto {}".format(t))
+                time.sleep(60)
+                t += 1
 
 def apagar():
-	print "Ejecutando poweroff"
+        print("Ejecutando poweroff")
+        os.system("sudo poweroff")
 
 if __name__ == "__main__":
-	mins = 0
-	if len(sys.argv) > 1 :
-		mins = int(sys.argv[1])
-	mensaje = "Advertencia el sistema se apagará en {} minutos"
-	if mins is not None and mins > 0:
-		print mensaje.format(mins)
-		temporizar(mins)
-	else:
-		print mensaje.format(10)
-		temporizar(10)
-	apagar()
+    mins = 0
+    if len(sys.argv) > 1:
+        try:
+            mins = int(sys.argv[1])
+        except ValueError:
+            print("El parámetro debe ser numérico")
+            sys.exit(1)
+    mensaje = "Advertencia el sistema se apagará en {} minutos"
+    if mins is not None and mins > 0:
+        print(mensaje.format(mins))
+        temporizar(mins)
+    else:
+        print(mensaje.format(10))
+        temporizar(10)
+    apagar()


### PR DESCRIPTION
## Summary
- ensure `pyshut.py` actually invokes `poweroff`
- add argument validation and migrate prints to Python 3

## Testing
- `python -m py_compile pyshut.py`

------
https://chatgpt.com/codex/tasks/task_e_6849b5ecb7a48328857cae8f25702a0b